### PR TITLE
Add missing managed policy to HealthCheck function

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -43,7 +43,9 @@ Resources:
       Handler: health_check.handler
       Runtime: python3.6
       CodeUri: build/health_check.zip
-      Policies: AWSLambdaFullAccess
+      Policies: 
+        - AWSLambda_FullAccess
+        - CloudWatchReadOnlyAccess
 
   Rollback:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
*Issue #, if available:*
#3 

*Description of changes:*
Add a managed policy for Cloudwatch to HealthCheck Lambda function to authorize the function to perform ```cloudwatch:GetMetricStatistics```.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
